### PR TITLE
Typo util -> utils

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -19,7 +19,7 @@
 #
 
 try:
-    from pydio.util import i18n
+    from pydio.utils import i18n
     _ = i18n.language.ugettext
 except ImportError:
     from utils import i18n


### PR DESCRIPTION
I have spotted a typo that makes all the import fail when I install from the sources. Since I've spent half an hour trying to find from where it was coming from, I let you benefit from the patch ;-)
